### PR TITLE
God Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ in-game.
 
 If not set, experience of the player will be set to `0.00`.
 
+#### \-\-god-mode
+
+Enables god mode.
+
+- You still take damage when god mode is enabled, you just can't die, even if your health is lower than zero.
+
 ### Arguments for game modes
 
 - In Native:

--- a/game/src/combat/plugin.rs
+++ b/game/src/combat/plugin.rs
@@ -19,7 +19,8 @@ impl Plugin for CombatPlugin {
         app.add_systems(Update, (damage_player, damage_enemies).in_set(GameplaySystems::Combat));
         app.add_systems(
             PostUpdate,
-            (player_death, enemy_death, despawn_projectiles).in_set(GameplaySystems::Combat),
+            (player_death.run_if(god_mode_is_disabled), enemy_death, despawn_projectiles)
+                .in_set(GameplaySystems::Combat),
         );
     }
 }

--- a/game/src/configuration/resources.rs
+++ b/game/src/configuration/resources.rs
@@ -27,6 +27,8 @@ pub struct Args {
     pub start_in_game_level: Option<NonZeroU16>,
     /// Experience to set when starting in game.
     pub start_in_game_experience: Option<f64>,
+    /// Flag to enable god mode.
+    pub enable_god_mode: bool,
 }
 
 impl Args {
@@ -72,6 +74,8 @@ impl Args {
             pub level: Option<NonZeroU16>,
             #[arg(long)]
             pub experience: Option<f64>,
+            #[arg(long)]
+            pub god_mode: bool,
         }
 
         impl Default for ArgsParser {
@@ -87,6 +91,7 @@ impl Args {
                     inventory: None,
                     level: None,
                     experience: None,
+                    god_mode: false,
                 }
             }
         }
@@ -122,6 +127,9 @@ impl Args {
                 }
                 if let Some(experience) = &self.experience {
                     write!(f, " --experience {}", Experience(*experience))?;
+                }
+                if self.god_mode {
+                    write!(f, " --god-mode")?;
                 }
                 Ok(())
             }
@@ -207,6 +215,7 @@ impl Args {
                     .collect();
                 let start_in_game_level = self.level;
                 let start_in_game_experience = self.experience;
+                let enable_god_mode = self.god_mode;
 
                 Args {
                     data_directory,
@@ -219,6 +228,7 @@ impl Args {
                     start_in_game_inventory,
                     start_in_game_level,
                     start_in_game_experience,
+                    enable_god_mode,
                 }
             }
         }

--- a/game/src/leveling/systems.rs
+++ b/game/src/leveling/systems.rs
@@ -16,6 +16,7 @@ pub fn apply_experience_command(
             query_result
         } else {
             reply!(command, "Not available outside the game.");
+            reply!(command, "");
             return;
         };
 
@@ -49,6 +50,7 @@ pub fn apply_level_command(
             query_result
         } else {
             reply!(command, "Not available outside the game.");
+            reply!(command, "");
             return;
         };
 

--- a/game/src/player/commands.rs
+++ b/game/src/player/commands.rs
@@ -1,0 +1,31 @@
+use crate::prelude::*;
+
+/// Controls the player.
+#[derive(ConsoleCommand, Parser)]
+#[command(name = "player")]
+#[command(disable_help_flag = true)]
+pub struct PlayerCommand {
+    #[clap(subcommand)]
+    pub subcommand: PlayerCommands,
+}
+
+/// Player commands.
+#[derive(Debug, Subcommand)]
+pub enum PlayerCommands {
+    /// Controls the god mode.
+    GodMode {
+        #[clap(subcommand)]
+        subcommand: GodModeCommands,
+    },
+}
+
+/// God mode commands.
+#[derive(Debug, Subcommand)]
+pub enum GodModeCommands {
+    /// Shows the status of god mode.
+    Status,
+    /// Enables god mode.
+    Enable,
+    /// Disables god mode.
+    Disable,
+}

--- a/game/src/player/conditions.rs
+++ b/game/src/player/conditions.rs
@@ -1,0 +1,12 @@
+use crate::prelude::*;
+
+
+/// Condition to run when god mode is enabled.
+pub fn god_mode_is_enabled(god_mode: Res<GodMode>) -> bool {
+    god_mode.is_enabled
+}
+
+/// Condition to run when god mode is disabled.
+pub fn god_mode_is_disabled(god_mode: Res<GodMode>) -> bool {
+    !god_mode.is_enabled
+}

--- a/game/src/player/mod.rs
+++ b/game/src/player/mod.rs
@@ -1,4 +1,6 @@
+pub mod commands;
 pub mod components;
+pub mod conditions;
 pub mod constants;
 pub mod interfaces;
 pub mod plugin;

--- a/game/src/player/plugin.rs
+++ b/game/src/player/plugin.rs
@@ -1,5 +1,8 @@
 use crate::{
-    player::systems::*,
+    player::{
+        commands::*,
+        systems::*,
+    },
     prelude::*,
 };
 
@@ -14,8 +17,18 @@ impl Plugin for PlayerPlugin {
         app.register_type::<SelectedMythologyIndex>();
         app.register_type::<SelectedPlayerIndex>();
 
+        // Register Resources.
+        app.register_type::<GodMode>();
+
+        // Insert resources.
+        let args = app.world.resource::<Args>();
+        app.insert_resource(GodMode { is_enabled: args.enable_god_mode });
+
         // Initialize registry.
         app.init_resource::<PlayerRegistry>();
+
+        // Add console commands.
+        app.add_console_command::<PlayerCommand, _>(apply_player_command);
 
         // Add systems.
         {

--- a/game/src/player/resources.rs
+++ b/game/src/player/resources.rs
@@ -9,3 +9,16 @@ pub struct SelectedMythologyIndex(pub usize);
 /// Resource for the index of the selected player.
 #[derive(Clone, Copy, Debug, Deref, Reflect, Resource)]
 pub struct SelectedPlayerIndex(pub usize);
+
+
+/// Resource for god mode.
+#[derive(Clone, Copy, Debug, Reflect, Resource)]
+pub struct GodMode {
+    pub is_enabled: bool,
+}
+
+impl Default for GodMode {
+    fn default() -> GodMode {
+        GodMode { is_enabled: false }
+    }
+}

--- a/game/src/player/systems.rs
+++ b/game/src/player/systems.rs
@@ -1,7 +1,47 @@
 use crate::{
-    player::constants::*,
+    player::{
+        commands::*,
+        constants::*,
+    },
     prelude::*,
 };
+
+
+/// Applies the inventory console commands.
+pub fn apply_player_command(
+    mut command: ConsoleCommand<PlayerCommand>,
+    mut god_mode: ResMut<GodMode>,
+) {
+    if let Some(Ok(PlayerCommand { subcommand })) = command.take() {
+        match subcommand {
+            PlayerCommands::GodMode { subcommand } => {
+                match subcommand {
+                    GodModeCommands::Status => {
+                        let status = if god_mode.is_enabled { "Enabled" } else { "Disabled" };
+                        reply!(command, "{}.", status);
+                    },
+                    GodModeCommands::Enable => {
+                        if god_mode.is_enabled {
+                            reply!(command, "Already enabled.");
+                        } else {
+                            god_mode.is_enabled = true;
+                            reply!(command, "Enabled.");
+                        }
+                    },
+                    GodModeCommands::Disable => {
+                        if god_mode.is_enabled {
+                            god_mode.is_enabled = false;
+                            reply!(command, "Disabled.");
+                        } else {
+                            reply!(command, "Already disabled.");
+                        }
+                    },
+                }
+            },
+        }
+        reply!(command, "");
+    }
+}
 
 
 /// Spawns the player.

--- a/game/src/prelude.rs
+++ b/game/src/prelude.rs
@@ -41,6 +41,7 @@ pub use crate::{
     physics::layers::*,
     player::{
         components::*,
+        conditions::*,
         interfaces::*,
         registry::*,
         resources::*,


### PR DESCRIPTION
This PR introduces god mode into the game, which can be activated either from the command line arguments, the query string in browsers, or console commands.

When enabled, player never dies, even if it's health drops below zero, which can happen since it would still take damage, just not die.